### PR TITLE
Allow any origins but restrict redirect_uri

### DIFF
--- a/helpers/apps.json
+++ b/helpers/apps.json
@@ -2,11 +2,11 @@
   "busy": {
     "app": "busy",
     "proxy": "busy.app",
-    "allowed_origins": [
-      "http://localhost:3000",
-      "http://localhost:8000",
-      "https://v2.steemconnect.com",
-      "https://busy.org"
+    "redirect_uris": [
+      "http://localhost:3000/demo",
+      "http://localhost:8000/demo",
+      "https://v2.steemconnect.com/demo",
+      "https://busy.org/callback"
     ]
   }
 }

--- a/helpers/middleware.js
+++ b/helpers/middleware.js
@@ -1,5 +1,4 @@
 const jwt = require('jsonwebtoken');
-const URL = require('url-parse');
 const apps = require('../helpers/apps.json');
 
 /**
@@ -47,11 +46,10 @@ const authenticateApp = (req, res, next) => {
 
 /**
  * Check if clientId is a valid app username
- * and if request origin is allowed by the app
+ * and if redirectUri is setup by the app
  */
-const verifyOrigin = (req, res, next) => {
-  const hostUrl = req.protocol + '://' + req.get('host');
-  const referrer = req.get('Referrer');
+const verifyApp = (req, res, next) => {
+  const redirectUri = req.query.redirect_uri;
   const clientId = req.query.client_id;
 
   const app = apps[clientId];
@@ -60,12 +58,9 @@ const verifyOrigin = (req, res, next) => {
     return res.redirect('/404');
   }
 
-  const url = new URL(referrer);
-  if (
-    (!referrer || app.allowed_origins.indexOf(url.origin) === -1)
-    && (url.origin !== hostUrl)
-  ) {
-    console.log(`Origin URL is not authorized for app @${clientId}.`);
+  if (!redirectUri || app.redirect_uris.indexOf(redirectUri) === -1)
+   {
+    console.log(`Redirect URI '${redirectUri}' is not authorized for app @${clientId}.`);
     return res.redirect('/404');
   }
   req.app = clientId;
@@ -98,6 +93,6 @@ const verifyPermissions = async (req, res, next) => {
 module.exports = {
   authenticateUser,
   authenticateApp,
-  verifyOrigin,
+  verifyApp,
   verifyPermissions,
 };

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "superagent": "^2.2.0",
     "tether": "^1.3.2",
     "url-loader": "^0.5.7",
-    "url-parse": "^1.1.8",
     "validator": "^5.1.0",
     "webpack": "^1.13.2",
     "webpack-visualizer-plugin": "^0.1.5"

--- a/public/demo/app.js
+++ b/public/demo/app.js
@@ -1,3 +1,9 @@
+sc2.init({
+  baseURL: 'http://localhost:3000',
+  app: 'busy',
+  callbackURL: 'http://localhost:3000/demo'
+});
+
 angular.module('app', [])
   .config(['$locationProvider', function($locationProvider){
     $locationProvider.html5Mode(true);
@@ -5,42 +11,20 @@ angular.module('app', [])
   .controller('Main', function($scope, $location, $http) {
     $scope.accessToken = $location.search().access_token;
     $scope.expiresIn = $location.search().expires_in;
+    $scope.loginURL = sc2.getLoginURL();
 
     if ($scope.accessToken) {
-      $http({
-        method: 'GET',
-        url: '/api/v1/me?access_token=' + $scope.accessToken
-      }).then(function (res) {
-        $scope.user = res.data
-      }, function (res) {
-        console.log('Access token is not valid.');
+      sc2.setAccessToken($scope.accessToken);
+      sc2.me(function (err, result) {
+        console.log('/me', err, result);
+        $scope.user = result;
+        $scope.$apply();
       });
     }
 
     this.submit = function() {
-      $http({
-        method: 'POST',
-        url: '/api/v1/broadcast?access_token=' + $scope.accessToken,
-        data: JSON.stringify({
-          operations: [
-            [
-              'vote',
-              {
-                voter: $scope.user.name,
-                author: 'snowflake',
-                permlink: 'test',
-                weight: 100,
-              }
-            ]
-          ]
-        })
-      }).then(function (res) {
-        console.log('Broadcast success', res);
-      }, function (res) {
-        console.log('Broadcast error', res);
+      sc2.vote($scope.user.name, 'siol', 'test', 100, function (err, result) {
+        console.log('/broadcast', err, result);
       });
-
-      $scope.comment = '';
-      $scope.$apply();
     }
   });

--- a/public/demo/index.html
+++ b/public/demo/index.html
@@ -6,27 +6,28 @@
   <meta charset="UTF-8">
   <meta id="viewport" name="viewport" content="initial-scale=1.0, maximum-scale=1.0, user-scalable=0"/>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <link rel="stylesheet" href="/bootstrap/dist/css/bootstrap.min.css" type="text/css" media="all"/>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css">
   <!--[if lt IE 9]><script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
   <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.3/angular.min.js"></script>
+  <script src="https://rawgit.com/adcpm/sc2-sdk/master/dist/sc2.min.js"></script>
   <script src="app.js"></script>
 </head>
 <body>
-  <div class="container py-5" style="max-width: 600px;" ng-controller="Main as main">
-    <h3>Demo</h3>
-    <div ng-show="!user">
-      <p>You are not logged, click below to login</p>
-      <a
-        href="/oauth2/authorize?client_id=busy&redirect_uri=/demo/"
-        class="btn btn-primary"
-      >
-        Login with SteemConnect
-      </a>
-    </div>
-    <form ng-show="user" ng-submit="main.submit()">
-      <p>You are now logged with <b>@{{user.name}}</b> account.</p>
-      <button class="btn btn-primary" type="submit">Vote @snowflake/test 1%</button>
-    </form>
+<div class="container py-5" style="max-width: 600px;" ng-controller="Main as main">
+  <h3>Demo</h3>
+  <div ng-show="!user">
+    <p>You are not logged, click below to login</p>
+    <a
+      ng-href="{{loginURL}}"
+      class="btn btn-primary"
+    >
+      Login with SteemConnect
+    </a>
   </div>
+  <form ng-show="user" ng-submit="main.submit()">
+    <p>You are now logged with <b>@{{user.name}}</b> account.</p>
+    <button class="btn btn-primary" type="submit">Vote @siol/test 1%</button>
+  </form>
+</div>
 </body>
 </html>

--- a/routes/oauth2.js
+++ b/routes/oauth2.js
@@ -2,12 +2,12 @@ const express = require('express');
 const qs = require('query-string');
 const debug = require('debug')('sc2:server');
 const config = require('../config.json');
-const { verifyOrigin, authenticateUser, verifyPermissions } = require('../helpers/middleware');
+const { verifyApp, authenticateUser, verifyPermissions } = require('../helpers/middleware');
 const { issueUserToken, issueAppToken } = require('../helpers/token');
 const { decryptMessage } = require('../helpers/hash');
 const router = express.Router();
 
-router.get('/authorize', verifyOrigin, authenticateUser, verifyPermissions, async (req, res, next) => {
+router.get('/authorize', verifyApp, authenticateUser, verifyPermissions, async (req, res, next) => {
   const redirectUri = req.query.redirect_uri;
 
   debug(`Issue token for app @${req.app}`);


### PR DESCRIPTION
There was a restriction to allow request to /oauth2/authorize only if the referrer origin url was listed by the app (in `/helpers/apps.json`). In case of mobile app there could be some issue to get referrer. I've removed this restriction and changed it for restrict redirect_uri instead. So instead of verify if the request come from a legit app with referer, we verify if the redirect_uri is legit to send a token to.